### PR TITLE
add compute instance perms

### DIFF
--- a/roles/astro-gcp-role.yaml
+++ b/roles/astro-gcp-role.yaml
@@ -37,6 +37,8 @@ includedPermissions:
 - compute.globalForwardingRules.pscSetLabels
 - compute.globalForwardingRules.setLabels
 - compute.globalOperations.get
+- compute.instances.delete
+- compute.instances.list
 - compute.networks.addPeering
 - compute.networks.create
 - compute.networks.delete


### PR DESCRIPTION
required in case of troubleshooting or triage. discovered when working with a customer.