### PR TITLE
Add permission required for converting clusters to use static NAT IPs

### DIFF
--- a/roles/astro-gcp-role-api-service-agent.yaml
+++ b/roles/astro-gcp-role-api-service-agent.yaml
@@ -52,6 +52,7 @@ includedPermissions:
 - compute.routers.create
 - compute.routers.delete
 - compute.routers.get
+- compute.routers.update
 - compute.subnetworks.create
 - compute.subnetworks.delete
 - compute.subnetworks.get


### PR DESCRIPTION
Add permission needed in order to update existing cluster routers to use static NAT egress IPs